### PR TITLE
Adding dragViewWithAccesibilityLabel:toViewWithAccesibilityLabel:

### DIFF
--- a/Classes/KIFUITestActor.h
+++ b/Classes/KIFUITestActor.h
@@ -299,6 +299,15 @@ static inline KIFDisplacement KIFDisplacementForSwipingInDirection(KIFSwipeDirec
 - (void)dragViewWithAccesibilityLabel:(NSString *)label toViewWithAccesibilityLabel:(NSString *)toLabel;
 
 /*!
+ @abstract Drags a particular view in the view hierarchy to drop on a point.
+ @discussion The view with the specified accesibility label will get dragged and dropped on specified point.
+ @param label The accessibility label of the view to drag.
+ @param point The point where the view will be dropped on to.
+ */
+
+- (void)dragViewWithAccesibilityLabel:(NSString *)label toPoint:(CGPoint)point;
+
+/*!
  @abstract Swipes a particular view in the view hierarchy in the given direction.
  @discussion The view will get the view with the specified accessibility label and swipe the screen in the given direction from the view's center.
  @param label The accessibility label of the view to swipe.

--- a/Classes/KIFUITestActor.h
+++ b/Classes/KIFUITestActor.h
@@ -290,6 +290,15 @@ static inline KIFDisplacement KIFDisplacementForSwipingInDirection(KIFSwipeDirec
 - (void)tapRowInTableViewWithAccessibilityLabel:(NSString*)tableViewLabel atIndexPath:(NSIndexPath *)indexPath;
 
 /*!
+ @abstract Drags a particular view in the view hierarchy to drop on another view.
+ @discussion The view with the specified accesibility label will get dragged and dropped on specified to accesibility label.
+ @param label The accessibility label of the view to drag.
+ @param toLabel The accesibility label of the view to be the end point to release touch. 
+ */
+
+- (void)dragViewWithAccesibilityLabel:(NSString *)label toViewWithAccesibilityLabel:(NSString *)toLabel;
+
+/*!
  @abstract Swipes a particular view in the view hierarchy in the given direction.
  @discussion The view will get the view with the specified accessibility label and swipe the screen in the given direction from the view's center.
  @param label The accessibility label of the view to swipe.

--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -489,6 +489,32 @@
     
 }
 
+- (void)dragViewWithAccesibilityLabel:(NSString *)label toViewWithAccesibilityLabel:(NSString *)toLabel
+{
+  
+  UIView *viewToDrag = nil;
+  UIAccessibilityElement *elementToDrag = nil;
+  
+  UIView *viewToDropOn = nil;
+  UIAccessibilityElement *elementDrop = nil;
+  
+  [self waitForAccessibilityElement:&elementToDrag view:&viewToDrag withLabel:label value:nil traits:UIAccessibilityTraitNone tappable:NO];
+  
+  [self waitForAccessibilityElement:&elementDrop view:&viewToDropOn withLabel:toLabel value:nil traits:UIAccessibilityTraitNone tappable:NO];
+  
+  // Within this method, all geometry is done in the coordinate system of
+  // the view to drag.
+  
+  CGRect elementFrame = [viewToDrag.window convertRect:elementToDrag.accessibilityFrame toView:viewToDrag];
+  CGPoint dragStart = CGPointCenteredInRect(elementFrame);
+  
+  CGRect elementStopFrame = [viewToDropOn.window convertRect:elementDrop.accessibilityFrame toView:viewToDropOn];
+  CGPoint dragStop = CGPointCenteredInRect(elementStopFrame);
+  
+  [viewToDrag dragFromPoint:dragStart toPoint:dragStop];
+}
+
+
 #define NUM_POINTS_IN_SWIPE_PATH 20
 
 - (void)swipeViewWithAccessibilityLabel:(NSString *)label inDirection:(KIFSwipeDirection)direction

--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -514,6 +514,26 @@
   [viewToDrag dragFromPoint:dragStart toPoint:dragStop];
 }
 
+- (void)dragViewWithAccesibilityLabel:(NSString *)label toPoint:(CGPoint)point
+{
+
+  UIView *viewToDrag = nil;
+  UIAccessibilityElement *elementToDrag = nil;
+  
+  
+  [self waitForAccessibilityElement:&elementToDrag view:&viewToDrag withLabel:label value:nil traits:UIAccessibilityTraitNone tappable:NO];
+  
+  
+  // Within this method, all geometry is done in the coordinate system of
+  // the view to drag.
+  
+  CGRect elementFrame = [viewToDrag.window convertRect:elementToDrag.accessibilityFrame toView:viewToDrag];
+  CGPoint dragStart = CGPointCenteredInRect(elementFrame);
+    
+  [viewToDrag dragFromPoint:dragStart toPoint:point];
+
+}
+
 
 #define NUM_POINTS_IN_SWIPE_PATH 20
 

--- a/KIF Tests/DraggingTests.m
+++ b/KIF Tests/DraggingTests.m
@@ -1,0 +1,40 @@
+//
+//  DragginTests.m
+//  KIF
+//
+//  Created by Seivan Heidari on 8/16/13.
+//
+//
+
+#import <KIF/KIF.h>
+
+@interface DraggingTests : KIFTestCase
+@end
+
+@implementation DraggingTests
+
+- (void)beforeEach
+{
+  [tester tapViewWithAccessibilityLabel:@"Dragging"];
+}
+
+- (void)afterEach
+{
+  [tester tapViewWithAccessibilityLabel:@"Test Suite" traits:UIAccessibilityTraitButton];
+}
+
+
+- (void)testDragViewWithAccessibilityLabel
+{
+  
+  [tester tapViewWithAccessibilityLabel:@"More"];
+  [tester tapViewWithAccessibilityLabel:@"Edit"];
+  [tester dragViewWithAccesibilityLabel:@"5" toViewWithAccesibilityLabel:@"0"];
+  [tester tapViewWithAccessibilityLabel:@"Done"];
+  [tester tapViewWithAccessibilityLabel:@"5" traits:UIAccessibilityTraitButton];
+  
+  
+  
+}
+
+@end

--- a/KIF Tests/DraggingTests.m
+++ b/KIF Tests/DraggingTests.m
@@ -24,12 +24,12 @@
 }
 
 
-- (void)testDragViewWithAccessibilityLabel
+- (void)testDragViewWithAccessibilityLabelToPoint
 {
   
   [tester tapViewWithAccessibilityLabel:@"More"];
   [tester tapViewWithAccessibilityLabel:@"Edit"];
-  [tester dragViewWithAccesibilityLabel:@"5" toViewWithAccesibilityLabel:@"0"];
+  [tester dragViewWithAccesibilityLabel:@"5" toPoint:CGPointMake(2, 432)];
   [tester tapViewWithAccessibilityLabel:@"Done"];
   [tester tapViewWithAccessibilityLabel:@"5" traits:UIAccessibilityTraitButton];
   

--- a/KIF Tests/TappingTests.m
+++ b/KIF Tests/TappingTests.m
@@ -48,4 +48,9 @@
     [tester waitForViewWithAccessibilityLabel:@"X" traits:UIAccessibilityTraitSelected];
 }
 
+//- (void)testDragViewWithAccessibilityLabel
+//{
+//    
+//}
+
 @end

--- a/KIF.xcodeproj/project.pbxproj
+++ b/KIF.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2203011B17BEA5ED00D7578B /* TabBarViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2203011A17BEA5ED00D7578B /* TabBarViewController.m */; };
+		2203011E17BEA6D000D7578B /* DraggingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2203011D17BEA6D000D7578B /* DraggingTests.m */; };
 		A88930121685098E00FC7C63 /* KIF.h in Headers */ = {isa = PBXBuildFile; fileRef = A88930111685098E00FC7C63 /* KIF.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EB02523E17AA109400A7D13A /* CompositionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EB02523D17AA109400A7D13A /* CompositionTests.m */; };
 		EB22B5B017AF52640090B848 /* CascadingFailureTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EB22B5AF17AF52640090B848 /* CascadingFailureTests.m */; };
@@ -91,6 +93,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		2203011A17BEA5ED00D7578B /* TabBarViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TabBarViewController.m; sourceTree = "<group>"; };
+		2203011D17BEA6D000D7578B /* DraggingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DraggingTests.m; sourceTree = "<group>"; };
 		39160B1013D1E6BB00311E38 /* LoadableCategory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LoadableCategory.h; sourceTree = "<group>"; };
 		A88930111685098E00FC7C63 /* KIF.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KIF.h; sourceTree = "<group>"; };
 		AAB0726B139719AC008AF393 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
@@ -318,6 +322,7 @@
 				EB9FB42617A5BACB00DDF160 /* GestureViewController.m */,
 				EB60ECFE177F9032005A041A /* TapViewController.m */,
 				EB60ECFF177F9032005A041A /* TestSuiteViewController.m */,
+				2203011A17BEA5ED00D7578B /* TabBarViewController.m */,
 				EB60ECC7177F8C83005A041A /* Supporting Files */,
 			);
 			path = "Test Host";
@@ -346,6 +351,7 @@
 				EB60ED09177F90BA005A041A /* SpecificControlTests.m */,
 				EB60ED0A177F90BA005A041A /* SystemTests.m */,
 				EB60ED0B177F90BA005A041A /* TappingTests.m */,
+				2203011D17BEA6D000D7578B /* DraggingTests.m */,
 				EB3F654417AA0B8400469D18 /* TableViewTests.m */,
 				EB02523D17AA109400A7D13A /* CompositionTests.m */,
 				EB60ED0C177F90BA005A041A /* TypingTests.m */,
@@ -548,6 +554,7 @@
 				EB60ED01177F9032005A041A /* ShowHideViewController.m in Sources */,
 				EB60ED02177F9032005A041A /* TapViewController.m in Sources */,
 				EB60ED03177F9032005A041A /* TestSuiteViewController.m in Sources */,
+				2203011B17BEA5ED00D7578B /* TabBarViewController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -568,6 +575,7 @@
 				EB60ED18177F90BA005A041A /* WaitForViewTests.m in Sources */,
 				EB3F654517AA0B8400469D18 /* TableViewTests.m in Sources */,
 				EB60ED1A177F90C2005A041A /* GestureTests.m in Sources */,
+				2203011E17BEA6D000D7578B /* DraggingTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/KIF.xcodeproj/xcshareddata/xcschemes/KIF.xcscheme
+++ b/KIF.xcodeproj/xcshareddata/xcschemes/KIF.xcscheme
@@ -37,6 +37,47 @@
                BlueprintName = "KIF Tests"
                ReferencedContainer = "container:KIF.xcodeproj">
             </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "CascadingFailureTests">
+               </Test>
+               <Test
+                  Identifier = "CompositionTests">
+               </Test>
+               <Test
+                  Identifier = "LongPressTests">
+               </Test>
+               <Test
+                  Identifier = "GestureTests">
+               </Test>
+               <Test
+                  Identifier = "ModalViewTests">
+               </Test>
+               <Test
+                  Identifier = "SystemTests">
+               </Test>
+               <Test
+                  Identifier = "SpecificControlTests">
+               </Test>
+               <Test
+                  Identifier = "TableViewTests">
+               </Test>
+               <Test
+                  Identifier = "TappingTests">
+               </Test>
+               <Test
+                  Identifier = "TypingTests">
+               </Test>
+               <Test
+                  Identifier = "WaitForAbscenceTests">
+               </Test>
+               <Test
+                  Identifier = "WaitForTappableViewTests">
+               </Test>
+               <Test
+                  Identifier = "WaitForViewTests">
+               </Test>
+            </SkippedTests>
          </TestableReference>
       </Testables>
    </TestAction>

--- a/Test Host/TabBarViewController.m
+++ b/Test Host/TabBarViewController.m
@@ -1,0 +1,44 @@
+//
+//  TabBarViewController.m
+//  KIF
+//
+//  Created by Seivan Heidari on 8/16/13.
+//
+//
+
+
+
+@interface TabBarViewController : UIViewController
+@property (strong, nonatomic) IBOutlet UITabBarController *aTabBarController;
+- (IBAction)popNavigation:(UIButton *)sender;
+@end
+
+@implementation TabBarViewController
+
+- (void)viewDidLoad
+{
+  [super viewDidLoad];
+  self.navigationController.navigationBarHidden = YES;
+  self.aTabBarController = [[UITabBarController alloc] init];
+  [self.view addSubview:self.aTabBarController.view];
+  
+  NSArray * viewControllers = @[];
+  for (NSInteger i = 0; i != 6; i++) {
+    UIViewController * vc = UIViewController.new;
+    vc.title = @(i).stringValue;
+    UIButton * btnPop = [UIButton buttonWithType:UIButtonTypeRoundedRect];
+    btnPop.frame = CGRectMake(10, 10, 200, 200);
+    [btnPop setTitle:@"Test Suite" forState:UIControlStateNormal];
+    [btnPop addTarget:self action:@selector(popNavigation:) forControlEvents:UIControlEventTouchUpInside];
+    [vc.view addSubview:btnPop];
+    viewControllers = [viewControllers arrayByAddingObject:vc];
+  }
+  self.aTabBarController.viewControllers = viewControllers;
+
+}
+- (IBAction)popNavigation:(UIButton *)sender
+{
+  [self.navigationController popViewControllerAnimated:YES];
+}
+
+@end

--- a/Test Host/en.lproj/MainStoryboard.storyboard
+++ b/Test Host/en.lproj/MainStoryboard.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="2.0" toolsVersion="4488.1" systemVersion="12E55" targetRuntime="iOS.CocoaTouch" variant="6xAndEarlier" propertyAccessControl="none" initialViewController="3">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="2.0" toolsVersion="3084" systemVersion="12D78" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" initialViewController="3">
     <dependencies>
         <deployment defaultVersion="1552" identifier="iOS"/>
         <development version="4600" identifier="xcode"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3715.3"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="2083"/>
     </dependencies>
     <scenes>
         <!--Navigation Controller-->
@@ -120,12 +120,34 @@
                                             <segue destination="gLb-0u-HV7" kind="push" id="OpP-KH-YLK"/>
                                         </connections>
                                     </tableViewCell>
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="blue" accessoryType="disclosureIndicator" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="Cell" textLabel="R5e-la-bRW" style="IBUITableViewCellStyleDefault" id="OyE-OY-rIr">
+                                        <rect key="frame" x="0.0" y="198" width="320" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
+                                            <rect key="frame" x="0.0" y="0.0" width="300" height="43"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" text="Dragging" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="R5e-la-bRW">
+                                                    <rect key="frame" x="10" y="0.0" width="280" height="43"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="20"/>
+                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="highlightedColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                </label>
+                                            </subviews>
+                                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                        </view>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                        <connections>
+                                            <segue destination="4wZ-w8-xah" kind="push" id="yvV-eR-174"/>
+                                        </connections>
+                                    </tableViewCell>
                                 </cells>
                             </tableViewSection>
                             <tableViewSection headerTitle="Modal Views" id="BQ9-XW-OMR">
                                 <cells>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="blue" accessoryType="disclosureIndicator" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="Cell" textLabel="aZL-Y3-JTh" style="IBUITableViewCellStyleDefault" id="mMs-db-L2N">
-                                        <rect key="frame" x="0.0" y="220" width="320" height="44"/>
+                                        <rect key="frame" x="0.0" y="264" width="320" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
                                             <rect key="frame" x="0.0" y="0.0" width="300" height="43"/>
@@ -144,7 +166,7 @@
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="blue" accessoryType="disclosureIndicator" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="Cell" textLabel="Iob-Ej-M2H" style="IBUITableViewCellStyleDefault" id="agW-My-ENo">
-                                        <rect key="frame" x="0.0" y="264" width="320" height="44"/>
+                                        <rect key="frame" x="0.0" y="308" width="320" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
                                             <rect key="frame" x="0.0" y="0.0" width="300" height="43"/>
@@ -163,7 +185,7 @@
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="blue" accessoryType="disclosureIndicator" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="Cell" textLabel="ccr-xP-4ye" style="IBUITableViewCellStyleDefault" id="BI1-7X-aTq">
-                                        <rect key="frame" x="0.0" y="308" width="320" height="44"/>
+                                        <rect key="frame" x="0.0" y="352" width="320" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
                                             <rect key="frame" x="0.0" y="0.0" width="300" height="43"/>
@@ -1168,6 +1190,22 @@
             </objects>
             <point key="canvasLocation" x="902" y="754"/>
         </scene>
+        <!--Tab Bar View Controller-->
+        <scene sceneID="wAV-Aj-PlU">
+            <objects>
+                <viewController wantsFullScreenLayout="YES" id="4wZ-w8-xah" customClass="TabBarViewController" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="RzD-2i-WUU">
+                        <rect key="frame" x="0.0" y="20" width="320" height="548"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="Qw5-lY-vZP"/>
+                    <nil key="simulatedTopBarMetrics"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="du4-WH-4gt" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1008" y="-678"/>
+        </scene>
         <!--Tap View Controller - Detail-->
         <scene sceneID="24">
             <objects>
@@ -1269,6 +1307,41 @@
             <point key="canvasLocation" x="902" y="64"/>
         </scene>
     </scenes>
+    <classes>
+        <class className="GestureViewController" superclassName="UIViewController">
+            <source key="sourceIdentifier" type="project" relativePath="./Classes/GestureViewController.h"/>
+            <relationships>
+                <relationship kind="outlet" name="bottomRightLabel" candidateClass="UILabel"/>
+                <relationship kind="outlet" name="lastSwipeDescriptionLabel" candidateClass="UILabel"/>
+                <relationship kind="outlet" name="scrollView" candidateClass="UIScrollView"/>
+            </relationships>
+        </class>
+        <class className="ShowHideViewController" superclassName="UIViewController">
+            <source key="sourceIdentifier" type="project" relativePath="./Classes/ShowHideViewController.h"/>
+            <relationships>
+                <relationship kind="outlet" name="aButton" candidateClass="UIButton"/>
+                <relationship kind="outlet" name="bButton" candidateClass="UIButton"/>
+                <relationship kind="outlet" name="contentLabel" candidateClass="UILabel"/>
+                <relationship kind="outlet" name="obscuringView" candidateClass="UIView"/>
+            </relationships>
+        </class>
+        <class className="TabBarViewController" superclassName="UIViewController">
+            <source key="sourceIdentifier" type="project" relativePath="./Classes/TabBarViewController.h"/>
+            <relationships>
+                <relationship kind="outlet" name="aTabBarController" candidateClass="UITabBarController"/>
+            </relationships>
+        </class>
+        <class className="TapViewController" superclassName="UIViewController">
+            <source key="sourceIdentifier" type="project" relativePath="./Classes/TapViewController.h"/>
+            <relationships>
+                <relationship kind="outlet" name="memoryWarningLabel" candidateClass="UILabel"/>
+                <relationship kind="outlet" name="slider" candidateClass="UISlider"/>
+            </relationships>
+        </class>
+        <class className="TestSuiteViewController" superclassName="UITableViewController">
+            <source key="sourceIdentifier" type="project" relativePath="./Classes/TestSuiteViewController.h"/>
+        </class>
+    </classes>
     <simulatedMetricsContainer key="defaultSimulatedMetrics">
         <simulatedStatusBarMetrics key="statusBar"/>
         <simulatedOrientationMetrics key="orientation"/>


### PR DESCRIPTION
:warning: Not ready to be merged because of failing test case but **I am looking for pointers.**

I need the ability to drag one view to on top of another. Check here for a sample https://gist.github.com/seivan/6253882 (or check the test case commited) - in the sample I'm using Swipe, but I had to add 14 objects in order to fit into the short range of the swipe. 

Added: `dragViewWithAccesibilityLabel:toPoint:` and `dragViewWithAccesibilityLabel:toViewWithAccesibilityLabel:`

I am considering adding `dragViewWithPoint:toPoint:` and   as well. But for now, lets focus on getting this to run. 

I could get my test case working using `- (void)swipeViewWithAccessibilityLabel:(NSString *)label inDirection:(KIFSwipeDirection)direction` 

But that only works if the direction is short enough for the swipe to work. However I can't get this to quite work, care to take a look at it? 

:warning: This branch only runs the new test case for now. :warning: 
